### PR TITLE
Remove Jira/Confluence refs; standardize on markdown outputs

### DIFF
--- a/.claude/skills/analyze-user-interview/SKILL.md
+++ b/.claude/skills/analyze-user-interview/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: analyze-user-interview
-description: Analyze a Zoom user interview — merges a VTT transcript with Confluence interview notes to produce a complete research summary with themes, pain points, friction points, and product signals, formatted for Confluence or saved as a local markdown file.
+description: Analyze a Zoom user interview — merges a VTT transcript with PM interview notes (markdown) to produce a complete research summary saved as a local markdown file.
 ---
 
 # User Interview Analyzer
 
 You are acting as a hybrid expert — part senior UX researcher, part Product Manager — analyzing a completed user interview. These sessions typically involve one user (the interviewee), a PM (the interviewer), and one or two engineers as observers. Treat this like a rigorous research artifact: extract signal, not noise.
 
-Your job is to merge two required inputs (Zoom VTT transcript + Confluence interview notes) and an optional third (Zoom video recording) into a single, cohesive, well-structured research summary.
+Your job is to merge two required inputs (Zoom VTT transcript + PM interview notes markdown file) and an optional third (Zoom video recording) into a single, cohesive, well-structured research summary saved as a local markdown file.
 
 ---
 
@@ -18,29 +18,16 @@ Before doing anything, confirm which inputs are available. Ask for any missing r
 | # | Input | Required | Description |
 |---|-------|----------|-------------|
 | 1 | **Zoom VTT transcript** | Yes | Path to the `.vtt` file from the Zoom recording |
-| 2 | **Confluence interview notes** | Yes | URL or page ID of the Confluence page with the interview template and PM notes |
+| 2 | **PM interview notes** | Yes | Path to the markdown file with the interview template and PM notes |
 | 3 | **Zoom video recording link** | No | Zoom cloud recording URL |
 
-If the user has not provided both required inputs, ask for them before proceeding. Do not guess file paths. Also ask for the Zoom video link if not provided — it will be referenced on the final page.
+If the user has not provided both required inputs, ask for them before proceeding. Do not guess file paths. Also ask for the Zoom video link if not provided — it will be referenced in the output.
 
 ---
 
-## Step 1: Read the Confluence Interview Notes
+## Step 1: Read the PM Interview Notes
 
-Fetch the Confluence page using the REST API:
-
-```bash
-AUTH_HEADER=$(python3 -c "import base64, os; u=os.environ['ATLASSIAN_USER']; t=os.environ['ATLASSIAN_TOKEN']; print(base64.b64encode(f'{u}:{t}'.encode()).decode())")
-
-# If the user provided a page URL, extract the page ID from it
-# URL pattern: https://YOUR_DOMAIN.atlassian.net/wiki/spaces/SPACE/pages/PAGE_ID/...
-# Or search by title if they gave a title instead of URL
-
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  "https://YOUR_DOMAIN.atlassian.net/wiki/rest/api/content/PAGE_ID?expand=body.storage,body.view,version,space,ancestors" | jq .
-```
-
-Extract and understand:
+Read the markdown file using the Read tool. Extract and understand:
 
 - **Interview goals** — What the PM was trying to learn; what decisions this informs
 - **Interview structure** — What questions/tasks were in the template
@@ -50,7 +37,7 @@ Extract and understand:
 
 ### 1a. Identify Existing Template Fields
 
-Scan the existing page for these fields. They are typically at the top of the page or in the interview template:
+Scan the existing file for these fields. They are typically at the top:
 
 - Date
 - Interviewer (name, role)
@@ -113,7 +100,7 @@ After resolving all speaker names, produce a cleaned version of the transcript:
 
 ## Step 3: Handle Video Input (Optional)
 
-If a Zoom video link was provided, you will reference it on the page (see Step 6). If the user also provided a local video file path:
+If a Zoom video link was provided, you will reference it in the output. If the user also provided a local video file path:
 
 > Note: Direct video analysis is not available. However, the video is valuable for observing screen-sharing portions of usability studies.
 
@@ -133,7 +120,7 @@ Incorporate any visual observations the user provides as **Screen Observation** 
 
 ## Step 4: Analyze — Extract Signal
 
-Working from the merged transcript + Confluence notes + any video observations, run a full research analysis. Apply your expertise as both a UX researcher and a PM. Look for:
+Working from the merged transcript + PM notes + any video observations, run a full research analysis. Apply your expertise as both a UX researcher and a PM. Look for:
 
 ### Themes
 Group related comments, behaviors, and moments across the session into 3–7 coherent themes. A theme is a pattern that appeared more than once — either in words, hesitation, a repeated question, or a consistent behavior.
@@ -170,7 +157,7 @@ Before composing the AI summary, clean up the human-written "Interview Notes:" s
 - Fix spelling, grammar, and punctuation errors
 - Expand obvious abbreviations (e.g., "ff" -> "feature flags", "perf" -> "performance")
 - Lightly clarify half-finished thoughts where the intent is obvious from context — keep the original meaning intact
-- Remove trailing blank lines / empty paragraphs (`<p />`) after the last bullet in each Interview Notes section to keep the document compact
+- Remove trailing blank lines / empty paragraphs after the last bullet in each Interview Notes section to keep the document compact
 - Preserve the bullet structure and content — do not add, remove, or reorder bullets
 
 **Do NOT:**
@@ -183,7 +170,7 @@ Before composing the AI summary, clean up the human-written "Interview Notes:" s
 
 ## Step 5: Compose the Research Summary
 
-Produce a structured, well-formatted research summary. **Do NOT include an "Interview Summary" header with Date/Interviewer/Interviewee/Observers/Duration/Goals in the AI analysis.** That information belongs in the interview template fields at the top of the page and will be updated there directly (see Step 6). The AI analysis starts with the Executive Summary.
+Produce a structured, well-formatted research summary. **Do NOT include an "Interview Summary" header with Date/Interviewer/Interviewee/Observers/Duration/Goals in the AI analysis.** That information belongs in the metadata section at the top of the output file. The AI analysis starts with the Executive Summary.
 
 Use this structure for the AI analysis content:
 
@@ -280,227 +267,46 @@ Concrete actions for the PM, ranked by priority:
 
 ---
 
-## Step 6: Confirm Output Destination
+## Step 6: Save Output as Markdown
 
-**Before writing or modifying anything**, ask the user:
+Save the analysis to the user's Desktop:
 
-> "The analysis is ready. How would you like me to save it?
->
-> 1. **Save locally as markdown** — I'll save the summary to your Desktop as `interview-analysis-[product-slug]-[YYYY-MM-DD].md`.
-> 2. **Update the Confluence interview page** — I'll append the AI analysis and update the interview metadata directly on the linked Confluence page.
->
-> Which would you prefer?"
+```
+~/Desktop/interview-analysis-[interviewee-slug]-[YYYY-MM-DD].md
+```
 
-Wait for confirmation. Do not write to Confluence or disk without the user's explicit choice.
+The output file follows this structure:
+
+```markdown
+# Interview Analysis: [Interviewee Name] — [YYYY-MM-DD]
+
+## Interview Metadata
+
+| Field | Value |
+|-------|-------|
+| **Date** | [date] |
+| **Interviewer** | [name, role] |
+| **Interviewee** | [name, role, team, tenure if known] |
+| **Observers** | [names, roles] |
+| **Interview Type** | [Open interview / Usability study / Mixture] |
+| **Product / Area** | [product area] |
+| **Duration** | [duration] |
+| **Zoom Recording** | [URL or N/A] |
+| **Champion Candidate** | [Yes / No / Unknown] |
+| **Early Adopter Candidate** | [Yes / No / Unknown] |
+| **Follow-Up Needed** | [Yes / No — details] |
 
 ---
 
-## Step 7: Deliver Output
+## Original PM Interview Notes
 
-### Confluence Page Layout — MANDATORY STRUCTURE
-
-When writing to Confluence (whether updating or creating a copy), the page MUST follow this exact layout from top to bottom. This layout is **non-negotiable** and must be consistent across ALL interview pages produced by this skill.
-
-#### Section 1: Interview Participant Info (very top of page)
-
-These fields go at the **very top** of the page, above everything else. Check the existing interview template for these fields and update them directly. If any are missing, add them.
-
-**Do NOT include:**
-- The interviewee's name as a heading — the Confluence page title already contains it
-- Interview Goals — these are part of the interview template and belong in the Interview Notes section
-- Duration — this is captured in the Interview Metadata table at the bottom
-
-**Required fields** — render as a **single `<p>` block** with `<br />` between each line (no separate paragraphs, no blank lines). This keeps the section tight and compact:
-
-```xml
-<p><strong>Zoom Video Recording:</strong> <a href="[URL]">[URL]</a><br />
-<strong>Date:</strong> [date]<br />
-<strong>Interviewer:</strong> <ac:link><ri:user ri:account-id="[ACCOUNT_ID]" /></ac:link>, [role]<br />
-<strong>Interviewee:</strong> <ac:link><ri:user ri:account-id="[ACCOUNT_ID]" /></ac:link>, [role, team, tenure if known]<br />
-<strong>Observers:</strong> <ac:link><ri:user ri:account-id="[ACCOUNT_ID]" /></ac:link> ([role]) &middot; <ac:link><ri:user ri:account-id="[ACCOUNT_ID]" /></ac:link> ([role])<br />
-<strong>Interview Type:</strong> [Open interview / Usability study / Mixture]<br />
-<strong>Product / Repo:</strong> [product area]<br />
-<strong>Relevant Context:</strong> [context]</p>
-```
-
-**@ mentioning people:** For every person referenced (interviewer, interviewee, observers), attempt to tag them using the Confluence `<ac:link><ri:user ri:account-id="..." /></ac:link>` markup. To find account IDs, search the Atlassian user directory:
-
-```bash
-AUTH_HEADER=$(python3 -c "import base64, os; u=os.environ['ATLASSIAN_USER']; t=os.environ['ATLASSIAN_TOKEN']; print(base64.b64encode(f'{u}:{t}'.encode()).decode())")
-
-# Search for a user by name
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  "https://YOUR_DOMAIN.atlassian.net/wiki/rest/api/search/user?cql=type=user%20AND%20user.fullname~%22[NAME]%22" | jq '.results[] | {accountId, displayName: .user.displayName}'
-```
-
-If the existing page already contains `<ri:user ri:account-id="...">` tags for any participants, reuse those account IDs. If a user cannot be found, fall back to plain text for that name.
-
-Do NOT duplicate these in the AI analysis section. If the template already has these fields, update them with data from the transcript. If a field is missing (e.g., "Interview Type" is not in the template), add it.
-
-#### Section 2: Interview Notes Callout Box
-
-Wrap the human interview notes in a Confluence panel with these exact colors:
-
-```xml
-<ac:structured-macro ac:name="panel" ac:schema-version="1" data-layout="default">
-  <ac:parameter ac:name="borderColor">#00875A</ac:parameter>
-  <ac:parameter ac:name="titleColor">#FFFFFF</ac:parameter>
-  <ac:parameter ac:name="borderWidth">2</ac:parameter>
-  <ac:parameter ac:name="titleBGColor">#00875A</ac:parameter>
-  <ac:parameter ac:name="title">Interview Notes</ac:parameter>
-  <ac:rich-text-body>
-    <p>These are the original interview notes captured by the interviewer during the session. They include the interview template questions, real-time observations, and post-interview reflections.</p>
-  </ac:rich-text-body>
-</ac:structured-macro>
-```
-
-**Color: Green (#00875A)** — This callout introduces the human-written interview notes section.
-
-The human interview notes content follows immediately after this callout. This includes:
-- Interview Goals
-- Warm-Up section
-- General Feedback section
-- Core Questions (all sub-questions)
-- Magic Wand section
-- Wrap-Up section
-- Post-Interview Notes table
-
-#### Section 3: AI Interview Analysis Callout Box
-
-After all human interview notes, add the AI analysis section wrapped in its own callout:
-
-```xml
-<ac:structured-macro ac:name="panel" ac:schema-version="1" data-layout="default">
-  <ac:parameter ac:name="borderColor">#0052CC</ac:parameter>
-  <ac:parameter ac:name="titleColor">#FFFFFF</ac:parameter>
-  <ac:parameter ac:name="borderWidth">2</ac:parameter>
-  <ac:parameter ac:name="titleBGColor">#0052CC</ac:parameter>
-  <ac:parameter ac:name="title">AI Interview Analysis &mdash; Generated [YYYY-MM-DD]</ac:parameter>
-  <ac:rich-text-body>
-    <p>This analysis was generated by the <strong>analyze-user-interview</strong> skill, merging the Zoom VTT transcript with the PM interview notes above. See the Interview Notes section above for the original template and observations.</p>
-  </ac:rich-text-body>
-</ac:structured-macro>
-```
-
-**Color: Blue (#0052CC)** — This callout introduces the AI-generated analysis section.
-
-The AI analysis content follows immediately after this callout:
-- Executive Summary
-- Key Themes (with sub-theme headings)
-- Pain Points (table)
-- Friction Points (table)
-- Frustrations (verbatim quotes)
-- What's Working (verbatim quotes)
-- Product Signals (table)
-- Notable Quotes
-- Transcript Coverage Notes
-- Recommended Next Steps
-
-#### Section 4: Interview Metadata Table (very bottom)
-
-The Interview Metadata table goes at the **very bottom** of the page, below everything else. This is the enriched reference table with all metadata about the interview.
-
-```xml
-<h2>Interview Metadata</h2>
-<table data-table-width="1800" data-layout="default">
-  <tbody>
-    <tr><th>Field</th><th>Value</th></tr>
-    <tr><td><strong>Interviewee</strong></td><td>[Name]</td></tr>
-    <tr><td><strong>Role / Title</strong></td><td>[Role]</td></tr>
-    <tr><td><strong>Team</strong></td><td>[Team name]</td></tr>
-    <tr><td><strong>Tenure</strong></td><td>[If known]</td></tr>
-    <tr><td><strong>Geographic Location</strong></td><td>[If known]</td></tr>
-    <tr><td><strong>Products They Work On</strong></td><td>[Products mentioned in interview]</td></tr>
-    <tr><td><strong>Repos They Work Out Of</strong></td><td>[If mentioned]</td></tr>
-    <tr><td><strong>Interviewer</strong></td><td>[Name, role]</td></tr>
-    <tr><td><strong>Observers</strong></td><td>[Names, roles]</td></tr>
-    <tr><td><strong>Interview Date</strong></td><td>[Date]</td></tr>
-    <tr><td><strong>Interview Type</strong></td><td>[Type]</td></tr>
-    <tr><td><strong>Duration</strong></td><td>[Duration]</td></tr>
-    <tr><td><strong>Zoom Video Recording</strong></td><td><a href="[ZOOM_URL]">[ZOOM_URL]</a></td></tr>
-    <tr><td><strong>Champion Candidate</strong></td><td>[Yes/No/Unknown]</td></tr>
-    <tr><td><strong>Early Adopter Candidate</strong></td><td>[Yes/No/Unknown]</td></tr>
-    <tr><td><strong>Follow-Up Needed</strong></td><td>[Yes/No — details]</td></tr>
-  </tbody>
-</table>
-```
-
-Fill in every field you can from the transcript and interview notes. If a field was already populated in the existing Post-Interview Notes table, preserve that value. If you discovered additional information from the transcript (e.g., products they mentioned working on, repos referenced), add it. Leave fields blank only if truly unknown.
-
-### Callout Box Summary
-
-| Callout | Color | Hex | Position |
-|---------|-------|-----|----------|
-| **Interview Notes** | Green | `#00875A` border + title BG, `#FFFFFF` title text | After participant info, before AI analysis |
-| **AI Interview Analysis** | Blue | `#0052CC` border + title BG, `#FFFFFF` title text | After interview notes, before metadata table |
-
-These colors and positions must be identical on every interview page. No exceptions.
+[Cleaned-up version of the PM's notes from the markdown input file, preserving structure]
 
 ---
 
-### If writing to Confluence (update existing page)
+## AI Interview Analysis — Generated [YYYY-MM-DD]
 
-Read the current page version first, then update:
-
-```bash
-AUTH_HEADER=$(python3 -c "import base64, os; u=os.environ['ATLASSIAN_USER']; t=os.environ['ATLASSIAN_TOKEN']; print(base64.b64encode(f'{u}:{t}'.encode()).decode())")
-
-# Get current version number
-VERSION=$(curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  "https://YOUR_DOMAIN.atlassian.net/wiki/rest/api/content/PAGE_ID?expand=version" | jq '.version.number')
-
-# Update the page (increment version)
-curl -s -H "Authorization: Basic $AUTH_HEADER" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -X PUT \
-  -d '{
-    "version": {"number": '$((VERSION + 1))'},
-    "title": "PAGE_TITLE",
-    "type": "page",
-    "body": {
-      "storage": {
-        "value": "[FULL_PAGE_XHTML]",
-        "representation": "storage"
-      }
-    }
-  }' \
-  "https://YOUR_DOMAIN.atlassian.net/wiki/rest/api/content/PAGE_ID" | jq '._links.webui'
-```
-
-### If creating a copy (sibling page)
-
-```bash
-AUTH_HEADER=$(python3 -c "import base64, os; u=os.environ['ATLASSIAN_USER']; t=os.environ['ATLASSIAN_TOKEN']; print(base64.b64encode(f'{u}:{t}'.encode()).decode())")
-
-# Create sibling page under the same parent
-curl -s -H "Authorization: Basic $AUTH_HEADER" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -X POST \
-  -d '{
-    "type": "page",
-    "title": "[Interviewee Name] - [Interview Topic] (AI Enhanced)",
-    "space": {"key": "SPACE_KEY"},
-    "ancestors": [{"id": "PARENT_PAGE_ID"}],
-    "body": {
-      "storage": {
-        "value": "[FULL_PAGE_XHTML]",
-        "representation": "storage"
-      }
-    }
-  }' \
-  "https://YOUR_DOMAIN.atlassian.net/wiki/rest/api/content" | jq '.id, ._links.webui'
-```
-
-Return the page URL so the user can view it immediately.
-
-### If saving locally
-
-Save the markdown file to the user's Desktop:
-
-```
-~/Desktop/interview-analysis-[product-slug]-[YYYY-MM-DD].md
+[Executive Summary through Recommended Next Steps as composed in Step 5]
 ```
 
 Confirm the file path after writing.
@@ -525,7 +331,7 @@ These rules apply throughout the analysis. Never violate them.
 - Generate themes from a single data point. One quote is a data point; a pattern across multiple moments is a theme.
 - Omit positive findings to appear more analytical. A balanced report builds more PM credibility.
 - Write for the user who was in the room. Write for the stakeholder who wasn't there.
-- Include an "Interview Summary" section with Date/Interviewer/Interviewee/etc. in the AI analysis — that information belongs in the template fields at the top of the page.
+- Include an "Interview Summary" section with Date/Interviewer/Interviewee/etc. in the AI analysis — that information belongs in the metadata table at the top.
 
 ---
 

--- a/.claude/skills/create-prd-claude-code/references/template.md
+++ b/.claude/skills/create-prd-claude-code/references/template.md
@@ -9,7 +9,7 @@
 | **Status** | Draft / Ready for Build |
 | **Target Repo** | [repo path or URL] |
 | **Language/Framework** | [e.g., TypeScript / Express.js / PostgreSQL] |
-| **Jira Epic** | [PROJ-XXX] |
+| **Design Doc** | [path/to/doc.md or N/A] |
 
 ---
 

--- a/.claude/skills/create-prd-engineering/SKILL.md
+++ b/.claude/skills/create-prd-engineering/SKILL.md
@@ -34,7 +34,7 @@ Ask the user for:
 7. **Dependencies** -- Other teams, services, or features this depends on
 8. **Release plan** -- What stages (Alpha, Beta, GA) and what are the criteria to advance?
 
-If the user provides a Jira epic, Confluence page, or design doc, read it for context.
+If the user provides a design doc or markdown spec, read it for context.
 
 ## Outputs
 
@@ -55,7 +55,7 @@ A comprehensive engineering PRD in markdown, following the template in `referenc
 
 ## Steps
 
-1. **Gather context** -- Ask for the inputs above. If a Jira epic or design doc exists, read it.
+1. **Gather context** -- Ask for the inputs above. If a design doc or markdown spec exists, read it.
 2. **Write the problem statement** -- Cover both user pain and business impact. Engineers build better when they understand why something matters.
 3. **Define functional requirements** -- Organize by feature area. Each requirement should describe a behavior: "When X happens, the system does Y." Avoid vague requirements like "the system should be fast."
 4. **Document technical constraints** -- Performance targets, backwards compatibility, security requirements, rate limits, data retention policies. Be specific.
@@ -73,7 +73,7 @@ A comprehensive engineering PRD in markdown, following the template in `referenc
 
 **Agent:** Asks about the event system architecture, expected event types, delivery guarantees, retry logic, and auth model. Produces a full engineering PRD with data model for webhook registrations, API contracts for CRUD + delivery, edge cases for failed deliveries, and acceptance criteria.
 
-**User:** "Write an engineering PRD for migrating from REST to GraphQL for our dashboard API. Here's the Confluence design doc."
+**User:** "Write an engineering PRD for migrating from REST to GraphQL for our dashboard API. Here's the design doc: docs/graphql-migration.md."
 
 **Agent:** Reads the design doc, maps the existing REST endpoints, and produces a PRD with the GraphQL schema, migration plan per endpoint, backwards compatibility approach, and release stages.
 

--- a/.claude/skills/create-prd-engineering/references/template.md
+++ b/.claude/skills/create-prd-engineering/references/template.md
@@ -8,7 +8,6 @@
 | **TPM** | [Name] |
 | **Date** | [YYYY-MM-DD] |
 | **Status** | Draft / Eng Review / Approved / In Progress |
-| **Jira Epic** | [PROJ-XXX] |
 | **Design Spec** | [Link] |
 | **Architecture Doc** | [Link, if applicable] |
 
@@ -183,8 +182,6 @@ ALTER TABLE [existing_table]
 - **Given** [precondition], **When** [action], **Then** [expected result]
 - **Given** [error condition], **When** [action], **Then** [error handling behavior]
 
-**Jira:** [PROJ-XXX or "To be created"]
-
 ---
 
 ### Story 2: [Story title]
@@ -195,8 +192,6 @@ ALTER TABLE [existing_table]
 
 - **Given** [precondition], **When** [action], **Then** [expected result]
 - **Given** [precondition], **When** [action], **Then** [expected result]
-
-**Jira:** [PROJ-XXX or "To be created"]
 
 ---
 

--- a/.claude/skills/create-prd/SKILL.md
+++ b/.claude/skills/create-prd/SKILL.md
@@ -28,7 +28,7 @@ Ask the user for:
 2. **Problem statement** -- What problem does this solve? Who has this problem?
 3. **Goals** -- What does success look like? What are we NOT trying to do?
 4. **Target users** -- Who are the primary users? Any secondary audiences?
-5. **Context** -- Any existing docs, Jira epics, Confluence pages, design files, or prior art?
+5. **Context** -- Any existing docs, design files, prior art, or markdown specs?
 6. **Constraints** -- Timeline, technical limitations, dependencies, or organizational constraints?
 
 If the user provides partial input, fill in what you can and mark gaps with `[TBD]` placeholders.
@@ -50,7 +50,7 @@ A complete PRD in markdown, following the template in `references/template.md`. 
 
 ## Steps
 
-1. **Gather inputs** -- Ask the user for the inputs listed above. If they provide a Jira epic or Confluence page, read it for context.
+1. **Gather inputs** -- Ask the user for the inputs listed above. If they provide a design doc or markdown file, read it for context.
 2. **Draft the problem statement** -- Write a clear, specific problem statement. Avoid jargon. Focus on the user's pain, not the solution.
 3. **Define goals and non-goals** -- Goals should be measurable. Non-goals are just as important -- they set boundaries and prevent scope creep.
 4. **Write user stories** -- Use "As a [user], I want to [action], so that [outcome]" format. Cover the primary persona first, then secondary.
@@ -66,11 +66,11 @@ A complete PRD in markdown, following the template in `references/template.md`. 
 
 **User:** "I need a PRD for a new notification preferences feature. Users have been complaining they get too many emails and can't control which ones they receive."
 
-**Agent:** Asks clarifying questions about target users, current notification types, any existing designs or Jira epics, and timeline constraints. Then produces a full PRD using the template.
+**Agent:** Asks clarifying questions about target users, current notification types, any existing designs or docs, and timeline constraints. Then produces a full PRD using the template.
 
-**User:** "Write a PRD for adding SAML SSO support. Here's the Jira epic: PROJ-456."
+**User:** "Write a PRD for adding SAML SSO support. Here's the design doc: docs/saml-sso.md."
 
-**Agent:** Reads the Jira epic for context, then produces a PRD that references the epic and fills in product context around the technical work.
+**Agent:** Reads the design doc for context, then produces a PRD that fills in product context around the technical work.
 
 ## Guardrails
 

--- a/.claude/skills/create-prd/references/template.md
+++ b/.claude/skills/create-prd/references/template.md
@@ -6,7 +6,6 @@
 | **Date** | [YYYY-MM-DD] |
 | **Status** | Draft / In Review / Approved |
 | **Stakeholders** | [PM, Eng Lead, Design Lead, TPM, etc.] |
-| **Jira Epic** | [PROJ-XXX] |
 | **Target Release** | [Alpha / Closed Beta / Open Beta / GA] |
 
 ---

--- a/.claude/skills/create-release-notes/SKILL.md
+++ b/.claude/skills/create-release-notes/SKILL.md
@@ -5,15 +5,12 @@ description: Monitor MRs into a codebase area and generate release notes summari
 
 # PM: Create Release Notes
 
-Generate weekly release notes by querying Jira Milestones (and optionally Epics)
-for a date range, cross-referencing with source code merge requests in GitLab,
-and checking Confluence for gaps. The primary source of truth is Jira; source code
-and Confluence serve as validation layers.
+Generate weekly release notes by cross-referencing GitLab merge requests with
+a user-provided feature list. The primary source of truth is the source code;
+the user's feature list provides business context and framing.
 
-This skill mirrors the weekly release notes process run by the release management
-team (e.g., the "[Action Required] Weekly Release Notes" emails), which
-queries Milestones with End Dates in a given week and asks PMs to contribute
-business-facing release notes for their features.
+This skill mirrors the weekly release notes process — querying shipped work in
+a given week and drafting business-facing notes that PMs can review and refine.
 
 ---
 
@@ -40,91 +37,29 @@ Before doing any work, confirm the following with the user:
 
    Calculate the dates based on today's date and the user's choice.
 
-2. **Issue Types** — Default to **Milestones** (matching the weekly release notes
-   process). Ask if the user also wants to include Epics:
+2. **Feature List (optional)** — Ask if the user wants to provide a list of
+   features shipping this week. This list is the business context layer:
 
-   > By default I'll query **Milestones** (matching the weekly release notes format).
-   > Should I also include **Epics**? This is useful for a more granular view.
+   > Do you have a list of features or items shipping this week? If so, paste
+   > them or provide a markdown file path. I'll use these alongside the MR data
+   > to generate accurate, business-facing release notes.
 
-3. **Source Repository (optional)** — Ask if the user wants to cross-reference
-   a GitLab source repository. If yes, collect:
+3. **Source Repository (optional but recommended)** — Ask if the user wants to
+   cross-reference a GitLab source repository. If yes, collect:
    - The repository path (e.g., `your-org/platform/your-product`)
-   - How far back to look for MRs (default: same as the Jira date range)
+   - How far back to look for MRs (default: same as the date range)
 
-4. **Scrum Team or Product (required for Confluence check)** — Ask which scrum
-   team or product area to search Confluence for. Examples:
-   - **Product:** Product A, Product B, Product C
-   - **Scrum Team:** Team Alpha, Team Beta, Team Gamma
+4. **Audience** — Ask who the release notes are for:
+   - **Internal teams** — Engineering, support, and PM stakeholders
+   - **External developers** — Public-facing changelog or docs
+   - **Both** — Generate two versions
 
-### Phase 2: Query Jira Milestones (Primary Source of Truth)
-
-Run a JQL query to find all Milestones shipping in the date range:
-
-```bash
-AUTH_HEADER=$(python3 -c "import base64, os; u=os.environ['ATLASSIAN_USER']; t=os.environ['ATLASSIAN_TOKEN']; print(base64.b64encode(f'{u}:{t}'.encode()).decode())")
-
-# Query Milestones with End Date in the specified range
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  -G --data-urlencode "jql=issuetype = Milestone AND \"End Date\" >= \"START_DATE\" AND \"End Date\" <= \"END_DATE\" ORDER BY assignee ASC, created DESC" \
-  --data-urlencode "maxResults=100" \
-  --data-urlencode "fields=summary,status,assignee,labels,customfield_10015,customfield_10014,project,description,components,fixVersions" \
-  "https://contoso.atlassian.net/rest/api/3/search" | jq .
-```
-
-If the user also wants Epics, run a second query:
-
-```bash
-# Query Epics with End Date in the specified range
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  -G --data-urlencode "jql=issuetype = Epic AND \"End Date\" >= \"START_DATE\" AND \"End Date\" <= \"END_DATE\" ORDER BY assignee ASC, created DESC" \
-  --data-urlencode "maxResults=100" \
-  --data-urlencode "fields=summary,status,assignee,labels,customfield_10015,customfield_10014,project,description,components,fixVersions" \
-  "https://contoso.atlassian.net/rest/api/3/search" | jq .
-```
-
-**Fields to extract for each Milestone/Epic:**
-- **Assignee** — PM or owner responsible for the feature
-- **Summary** — Title/description of the feature
-- **Key** — Jira issue key (e.g., PROJ-4875)
-- **End Date** — Ship date (`customfield_10015` — verify on first run)
-- **Current Release Stage** — The current stage (Alpha, Closed Beta, Open Beta, GA).
-  Look in labels, fixVersions, or a custom field. If not available directly,
-  check the linked release in your feature flag platform or infer from labels.
-- **Next Release Stage Date** — When the next stage transition is planned.
-  Look in custom fields or linked issues.
-- **Status** — Jira status (Done, In Progress, etc.)
-- **Project** — Jira project
-- **Components** — Component labels
-- **Description** — First 200 chars for context
-
-**If the user specified a scrum team**, add a team/label filter to the JQL:
-
-```
-AND (labels = "team-alpha" OR "Scrum Team" = "Team Alpha")
-```
-
-**If the user specified a product**, add a project or component filter:
-
-```
-AND (project = "PROD" OR component = "Product A")
-```
-
-**Present results in the weekly release notes format, sorted by Assignee:**
-
-| Assignee | Summary | Key | End Date | Current Release Stage | Next Release Stage Date |
-|----------|---------|-----|----------|-----------------------|-------------------------|
-| Jane Smith | Campaign Level Portfolio View Settings Snapshot | PROJ-4875 | 1/30/26 | Alpha | 1/14/26 |
-| Alex Johnson | Generate weekly summary of Reliability SLOs | PROJ-5123 | 1/30/26 | | |
-
-This table matches the format sent by the release management team in the weekly
-"[Action Required] Weekly Release Notes" email.
-
-### Phase 3: Cross-Reference with Source Code (Secondary Validation)
+### Phase 2: Query Source Code (Primary Source of Truth)
 
 **Skip this phase if the user did not provide a GitLab repository.**
 
 If a source repository was specified, use the Sourcegraph MCP tools to find
-merge requests / commits completed in the same date range:
+merge requests / commits completed in the date range:
 
 ```
 sg_commit_search with:
@@ -135,74 +70,65 @@ sg_commit_search with:
 
 Also use `sg_diff_search` for broader pattern matching if needed.
 
-**Compare Jira Milestones vs. Source Code:**
+**For each MR / commit, extract:**
+- **Title** — Summary of what changed
+- **Author** — Who shipped it
+- **Merged date** — When it landed
+- **Description** — First 200 chars for context
+- **Labels / tags** — Any release stage, team, or category labels
 
-1. **Behind schedule (in Jira but no MR):** Flag any Milestones marked as "Done"
-   or with an End Date in the range that have NO corresponding MR in the repository.
-   These may be behind or may live in a different repo.
+**Present results in a working table:**
 
-2. **Not in Jira (MR exists but no Milestone):** Flag any significant MRs (not
-   just small fixes/refactors) that don't match any Jira Milestone. These might
-   need to be added to release notes as undocumented changes.
+| Author | Summary | Merged Date | Labels |
+|--------|---------|-------------|--------|
+| Jane Smith | Campaign Level Portfolio View Settings Snapshot | 2026-01-30 | alpha |
+| Alex Johnson | Generate weekly summary of Reliability SLOs | 2026-01-30 | |
+
+### Phase 3: Reconcile Feature List vs. Source Code
+
+**Run this phase if the user provided both a feature list and a repository.**
+
+Compare the user-provided feature list against the MRs found:
+
+1. **In the list but no MR found:** Flag items the user expects to be shipping
+   that have no corresponding MR in the repository. These may be in a different
+   repo, still in progress, or the dates may not align.
+
+2. **MR exists but not in the list:** Flag any significant MRs that don't match
+   items in the user's feature list. These might need to be added to release
+   notes as undocumented changes.
 
 Present findings as a gap analysis:
 
-#### Potential Gaps: Milestones Without MRs
-| Key | Summary | Status | Concern |
-|-----|---------|--------|---------|
-| PROJ-1234 | Feature X | Done | No matching MR found in repo |
+#### Potential Gaps: Features Without MRs
+| Feature | Concern |
+|---------|---------|
+| Feature X | No matching MR found in repo — confirm it's shipping |
 
-#### Potential Gaps: MRs Without Jira Milestones
+#### Potential Gaps: MRs Without Feature Entries
 | MR / Commit | Description | Author | Concern |
 |-------------|-------------|--------|---------|
-| abc1234 | Major refactor of auth module | author@example.com | No matching Milestone found |
+| abc1234 | Major refactor of auth module | author@example.com | Not in feature list — add to notes? |
 
-### Phase 4: Check Confluence for Gaps (Tertiary Validation)
+### Phase 4: Generate Release Notes
 
-**This phase requires a Scrum Team or Product to be specified.**
+Using the data from all sources, generate two outputs:
 
-Search Confluence for pages related to the scrum team or product that were
-created or updated in the date range:
+#### Output A: Weekly Release Notes Table (for PM review)
 
-```bash
-# Search Confluence for relevant pages
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  -G --data-urlencode "cql=text ~ 'TEAM_OR_PRODUCT' AND type = page AND lastModified >= 'START_DATE' ORDER BY lastModified DESC" \
-  --data-urlencode "limit=25" \
-  "https://contoso.atlassian.net/wiki/rest/api/content/search" | jq .
-```
+This is the summary table for confirming what's shipping:
 
-**What to look for in Confluence:**
-- PRDs or design docs for features not captured in the Jira query
-- Existing weekly release notes pages that may have additional context
-- Sprint review or demo pages with shipped features
-- Decision logs or architecture docs indicating significant changes
+| Author | Summary | Merged Date | Release Stage |
+|--------|---------|-------------|---------------|
 
-Flag anything in Confluence that suggests a shipped feature NOT already
-captured in the Jira Milestones list.
-
-### Phase 5: Generate Release Notes
-
-Using the data from all three sources, generate two outputs:
-
-#### Output A: Weekly Release Notes Table (for the release manager)
-
-This is the table format matching the weekly email. PMs use this to confirm
-what's shipping and update their entries:
-
-| Assignee | Summary | Key | End Date | Current Release Stage | Next Release Stage Date |
-|----------|---------|-----|----------|-----------------------|-------------------------|
-
-Include instructions matching the release manager's email:
+Include review instructions:
 1. If business-facing and shipping this week, the item belongs in release notes
-2. If not scheduled to ship, flag it so the End Date can be updated in Jira
+2. If not shipping, flag it for follow-up
 3. Note the deadline (typically EOD Thursday before the ship week)
 
 #### Output B: Business-Facing Release Notes (for stakeholders)
 
-Generate release notes following the template in
-`prompts/claude/release-notes-writer.xml`. Categorize each item using standard
-changelog categories:
+Generate release notes using standard changelog categories:
 
 - **New** — New features, capabilities, endpoints
 - **Changed** — Modified behavior, performance improvements, updated defaults
@@ -215,42 +141,74 @@ changelog categories:
 - Lead with developer/user impact, not implementation details
 - Be precise about what changed and where
 - For breaking changes, include migration guidance
-- Reference Jira Milestone/Epic keys so readers can drill into details
 - Note the release stage (Alpha, Closed Beta, Open Beta, GA) for each item
-- Group items by product area or scrum team when multiple teams are covered
+- Group items by product area or team when multiple teams are covered
 
 **Present a draft to the user for review before finalizing.**
 
-### Phase 6: Review & Iterate
+### Phase 5: Review & Iterate
 
 After presenting the draft:
 1. Ask if any items should be added, removed, or reworded
-2. Ask about audience — is this for external developers, internal teams, or both?
-3. Ask if any items are breaking changes requiring migration guidance
+2. Confirm the audience — is this for external developers, internal teams, or both?
+3. Ask about breaking changes requiring migration guidance
 4. Flag items that appear to be missing release stage information
-5. Flag items where the End Date may need updating (not actually shipping)
-6. Iterate until the user approves
+5. Iterate until the user approves
+
+### Phase 6: Save as Markdown
+
+Save the final release notes to the user's Desktop:
+
+```
+~/Desktop/release-notes-[YYYY-MM-DD].md
+```
+
+The output file follows this structure:
+
+```markdown
+# Release Notes — Week of [MM/DD]
+
+## Summary Table
+
+| Author | Summary | Merged Date | Release Stage |
+|--------|---------|-------------|---------------|
 
 ---
 
-## Custom Field Reference
+## New
 
-Jira custom fields vary by instance. On first run, if the End Date field
-(`customfield_10015`) doesn't return data, discover the correct field:
+### [Feature Title]
 
-```bash
-# Get all fields to find the End Date custom field ID
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  "https://contoso.atlassian.net/rest/api/3/field" | jq '.[] | select(.name | test("end date"; "i"))'
+**Release Stage:** [Alpha / Closed Beta / Open Beta / GA]
+
+[Business-facing description of what changed and why it matters]
+
+---
+
+## Changed
+
+[Same format]
+
+---
+
+## Fixed
+
+[Same format]
+
+---
+
+## Deprecated / Removed
+
+[Same format]
+
+---
+
+## Security
+
+[Same format]
 ```
 
-Similarly, discover fields for Current Release Stage and Next Release Stage Date:
-
-```bash
-# Find release stage fields
-curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
-  "https://contoso.atlassian.net/rest/api/3/field" | jq '.[] | select(.name | test("release stage"; "i"))'
-```
+Confirm the file path after writing.
 
 ---
 
@@ -258,41 +216,12 @@ curl -s -H "Authorization: Basic $AUTH_HEADER" -H "Accept: application/json" \
 
 This skill supports the weekly release notes process:
 
-1. **Release management** sends a weekly email on Wednesday
-   titled "[Action Required] Weekly Release Notes MM/DD-MM/DD"
-2. The email contains a table of Milestones with End Dates in the upcoming ship week
-3. PMs review the table and either:
-   - Add business-facing release notes to the shared document if their feature is shipping
-   - Update the End Date in Jira if the feature is not shipping that week
-4. Deadline is **EOD Thursday** before the ship week
-5. Once reviewed and approved, release notes are moved to Confluence
+1. Release management announces the upcoming ship week (typically mid-week)
+2. PMs review what's shipping and either add business-facing notes or flag items not shipping
+3. Deadline is typically **EOD Thursday** before the ship week
+4. Once reviewed, the final markdown is shared with stakeholders
 
-### Published Release Notes Reference
-
-The canonical published release notes live on the **Product Weekly Release Notes**
-Confluence page. Check your Confluence instance for the published release notes page
-in the PROD space.
-
-This page is the best reference for the final published format. Key structural
-elements to match when generating release notes:
-
-- **Weekly heading** — `Week MM/DD` with a blue heading style
-- **Table of Contents** — Numbered list of feature titles linking to anchors
-- **Per-feature sections** include:
-  - **Release Stage Timeline** — Table with columns: Release Stage (Alpha, Closed Beta, Open Beta, GA) and Date for each
-  - **Feature Overview** — Business-facing description of what changed and why it matters
-  - **How to use this feature** — Step-by-step instructions with screenshots
-  - **How do I get access?** — Internal vs. external access instructions
-  - **Where can I learn more or ask questions?** — POC contact
-  - **Product Resources** — Slack channels, Confluence links
-  - **Product Marketing Narrative & Commercial Training Resources** — Training links, recordings, guides
-- **Index + Past Notes** — Link to archived notes and a TOC of all past entries
-- Notes are published every **Tuesday at 1:00 PM ET** and announced in `#product-updates`
-
-Use this page as a reference when formatting the final output in Phase 5.
-
-This skill automates step 2 — generating the table and drafting business-facing
-release notes — so PMs can review and refine rather than write from scratch.
+This skill automates step 2 — generating the summary table and drafting business-facing notes — so PMs can review and refine rather than write from scratch.
 
 ---
 
@@ -311,22 +240,18 @@ Would you like to:
 3. Specify a longer duration (e.g., last 30 days, full quarter)
 4. Specify a custom date range (including future dates)
 
-**Issue Types:** I'll query Milestones by default (matching the weekly release
-notes format). Should I also include Epics for a more granular view?
+**Feature List (optional):** Do you have a list of features shipping this week?
+Paste them or provide a markdown file path.
 
-**Optional — Source Code:** Do you want to cross-reference a GitLab repository?
-If so, which one?
+**Source Repository (optional):** Do you want to cross-reference a GitLab
+repository? If so, which one?
 
-**Required — Team/Product:** What scrum team or product should I search in
-Confluence? (e.g., "Product A" as a product, or "Team Alpha" as a scrum team)
+**Audience:** Are these notes for internal teams, external developers, or both?
 ```
 
 ---
 
 ## Dependencies
 
-- **Required:** `ATLASSIAN_USER` and `ATLASSIAN_TOKEN` environment variables
-- **Required:** Jira access with permission to query Milestones and Epics
 - **Optional:** Sourcegraph MCP tools (for GitLab cross-reference)
-- **Optional:** Confluence access (for gap analysis)
 - **Reference:** `prompts/claude/release-notes-writer.xml` for output template

--- a/.claude/skills/jobs-to-be-done/SKILL.md
+++ b/.claude/skills/jobs-to-be-done/SKILL.md
@@ -90,7 +90,7 @@ Ask these questions:
 - Who is mentioned as a user, stakeholder, or audience in design docs, PRDs, and strategy docs?
 - Who appears in the RBAC/permissions model? Different permission levels often indicate different personas
 - Who is mentioned in onboarding guides? Are there different guides for different roles?
-- Who files bugs, requests features, or gives feedback in Slack/Jira?
+- Who files bugs, requests features, or gives feedback in Slack or issue trackers?
 
 **From the codebase:**
 - What authentication roles exist? (admin, developer, viewer, integrations)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,36 @@
-# AGENTS.md — Project Instructions & Agent Definitions
-
-Source of truth for this repo. Claude Code, Codex, and other AI tools read
-this file for all project context.
-
----
+# AGENTS.md
 
 ## Operating Rules
 
-- Use the closest matching skill in `.claude/skills/` before inventing a new workflow.
-- Prefer simple, working solutions over clever abstractions.
-- Write code that is easy to read and modify, not code that is impressive.
-- When in doubt, ask — don't burn tokens guessing.
-- Never add work confidential information, internal names, or private corporate links.
-- New prompts go in `prompts/` following the conventions in [prompt-library.md](prompts/prompt-library.md).
+- Check `.claude/skills/` first before inventing a new workflow.
+- Prefer simple, working solutions. Write readable code, not impressive code.
+- Ask one clarifying question rather than burning tokens on bad drafts.
+- Never include confidential info, internal names, or private links.
+- New prompts go in `prompts/` — see [prompt-library.md](prompts/prompt-library.md).
+- Batch related changes into single interactions.
+- Route all art/image work to Gemini or Grok with ready-to-paste prompts.
 
-## Resource Constraints
-
-> **Read this section before estimating work or planning multi-step tasks.**
-
-| Tool | Plan | Budget | Use For |
-|------|------|--------|---------|
-| Claude Code | Pro | Limited monthly | Code generation, architecture, planning |
-| Claude.ai | Pro | Limited monthly | Writing, research, conversation |
-| ChatGPT Plus | Plus | ~40 msgs / 3 hrs | Writing, brainstorming, research |
-| OpenAI Codex | Plus (shared) | ~40 msgs / 3 hrs | Code generation, second opinion |
-| Gemini | Free | Unlimited | Art generation, image assets only |
-| Grok | Free | Unlimited | Art generation, image assets only |
-
-**Subagent model selection:**
+## Subagent Models
 
 | Model | Use For |
 |-------|---------|
-| `haiku` | Quick file searches, simple formatting, grep-like tasks |
-| `sonnet` | Code reviews, docs, straightforward refactoring, research |
-| `opus` | Architecture decisions, multi-step planning, security audits |
+| `haiku` | File searches, simple formatting |
+| `sonnet` | Code reviews, docs, refactoring, research |
+| `opus` | Architecture, multi-step planning, security audits |
 
-Default to `haiku` for exploration, `sonnet` for implementation. Only use
-`opus` when the task genuinely requires deep reasoning.
-
-**Execution rules:**
-
-1. Produce working code in 1-2 iterations. Ask a clarifying question first — one question is cheaper than three bad drafts.
-2. Include estimated AI interactions alongside time estimates.
-3. Make prompts self-contained — reference file paths, function names, and expected inputs/outputs explicitly.
-4. Batch related changes into single interactions to minimize context-switching.
-5. Front-load planning. A good plan in one turn saves 5 turns of rework.
-6. Route all art/image work to Gemini or Grok with ready-to-paste prompts.
-
----
-
-## Skill Contract
-
-Every skill lives at `.claude/skills/<kebab-case>/SKILL.md` and includes:
-Purpose, When to use, Inputs, Outputs, Steps, Examples, Non-goals / Guardrails.
-
-**Naming:**
-- Active skills: descriptive kebab-case (e.g., `decision-brief`, `question-storming`)
-- Placeholders not yet built: `todo-` prefix (e.g., `todo-launch-checklist`)
-- When a `todo-` skill is built out, remove the prefix and update the catalog below
+Default to `haiku` for exploration, `sonnet` for implementation.
 
 ## Conventions
 
-### Files & Structure
+**Structure:**
+- Skills: `.claude/skills/<kebab-case>/SKILL.md` + optional `references/`
+- Active skills: kebab-case · Unbuilt: `todo-` prefix · Remove prefix when built
+- Prompts: `prompts/claude/` (XML) · `prompts/gpt/` (MD) · `prompts/gemini/` (MD)
+- CLAUDE.md points here — all real config lives in this file
 
-- Markdown for all config and documentation.
-- Skills: `.claude/skills/`, each with `SKILL.md` and optional `references/` directory.
-- Prompts: `prompts/claude/` (XML), `prompts/gpt/` (Markdown), `prompts/gemini/` (Markdown).
-- CLAUDE.md is a pointer to this file — all real config lives here.
+**Output:** All outputs are markdown files unless creating a PowerPoint.
 
-### Large File Policy
-
-Do NOT commit files above these limits without explicit user approval:
+**Large File Policy** — don't commit without user approval:
 
 | File type | Limit |
 |-----------|-------|
@@ -78,161 +38,50 @@ Do NOT commit files above these limits without explicit user approval:
 | Images (`.png`, `.jpg`, `.gif`) | 5 MB |
 | Any single file | 25 MB |
 
-Always `ls -lh <file>` before staging. Never use `git add .` or `git add -A`.
-If over the limit: stop, tell the user, suggest compression or cloud storage.
+Always `ls -lh <file>` before staging. Never `git add .` or `git add -A`.
 
-### Document Types
+**Document types:**
+1. `DESIGN.md` — what and why (`docs/`)
+2. `<feature>-concept.md` — how it feels (`docs/concepts/`)
+3. `<feature>-execution.md` — how to build it (`docs/execution/`)
 
-Three tiers, each linking to the next:
-
-1. **Design Document** — The "what and why." Location: `docs/` or project root. Naming: `DESIGN.md`.
-2. **Concept Direction** — The "how it feels." Location: `docs/concepts/`. Naming: `<feature>-concept.md`.
-3. **Execution Document** — The "how to build it." Location: `docs/execution/`. Naming: `<feature>-execution.md`. Includes architecture, implementation steps, and ready-to-paste prompts.
-
----
-
-## Internal Tools & Platforms
-
-### Atlassian (Jira + Confluence)
-
-All project tracking, documentation, and IP lives in Atlassian.
-
-> **Always use the CLI** to read from and write to Jira and Confluence.
-> Never ask the user to manually copy-paste from the browser.
-> See [docs/atlassian-api.md](docs/atlassian-api.md) for auth setup and API examples.
-
-**Jira hierarchy:**
-
-```text
-Initiative → Milestone → Epic → Story
-```
-
-### Product Release Stages
+## Release Stages
 
 | Stage | Access | Quality Bar |
 |-------|--------|-------------|
-| **Alpha** | Internal team only | Dev complete; bugs being triaged |
-| **Closed Beta** | All employees + select partners | No P0/P1 issues |
-| **Open Beta** | All employees + early adopters | No P0/P1/P2 issues |
-| **GA** | All customers | Feature complete; no critical issues |
-
-Progression: Alpha → Closed Beta (fix P0/P1, start marketing/training) → Open Beta (holdout experiments, runbooks approved) → GA (metrics trending up, full launch).
-
-### Monitoring
-
-Grafana: `https://contoso.grafana.net/` (SSO). Dashboard URL pattern:
-`https://contoso.grafana.net/d/<UID>/<slug>?orgId=1&from=now-30d&to=now&timezone=utc`
-
----
-
-## Role Guidelines
-
-### Planner
-
-Project architect and estimation lead.
-- Read Resource Constraints before estimating.
-- Break work into token-efficient chunks. State what each task produces, estimated AI interactions, and which tool handles it.
-- Produce a clear plan before any code generation begins.
-
-### Builder
-
-Code generation and implementation.
-- Generate complete, working code — not stubs or pseudocode.
-- Batch related changes into single interactions.
-- Route art/image work to Gemini or Grok with ready-to-paste prompts.
-- Flag when a task will likely exceed a single session's token budget.
-
----
+| Alpha | Internal only | Dev complete, bugs triaged |
+| Closed Beta | All employees + select partners | No P0/P1 |
+| Open Beta | All employees + early adopters | No P0/P1/P2 |
+| GA | All customers | Feature complete, no critical issues |
 
 ## Skill Catalog
 
-All skills live in `.claude/skills/` and are auto-discovered by Claude Code.
-
 ### PM Practice Skills
 
-| Skill | Path | Description |
-|-------|------|-------------|
-| Create PRD | `create-prd/` | Standard PRD for cross-functional audiences |
-| Create PRD (Claude Code) | `create-prd-claude-code/` | PRD optimized for AI coding agents to build from |
-| Create PRD (Engineering) | `create-prd-engineering/` | Detailed PRD for engineering teams with technical depth |
-| Create PRD (One-Pager) | `create-prd-one-pager/` | 1-page PRD for leadership and partner audiences |
-| Decision Brief (SOCRR) | `decision-brief/` | Prepare decision briefings using the SOCRR framework |
-| Question Storming | `question-storming/` | Run question-storming sessions to explore problem spaces |
-| Jobs to Be Done | `jobs-to-be-done/` | Create personas and use cases using the JTBD framework |
-| Create User Interview | `create-user-interview/` | Create minimalist user interview templates |
-| Analyze User Interview | `analyze-user-interview/` | Analyze completed user interviews into research summaries |
-| DevEx Survey | `devex-survey/` | Create and analyze Developer Experience surveys |
-| Create Architecture Diagram | `create-architecture-diagram/` | Three-tier architecture diagrams using Mermaid |
-| Create Release Notes | `create-release-notes/` | Generate release notes from Jira + source repos |
-| Sourcegraph Search | `sourcegraph-search/` | Cross-repo code search via Sourcegraph MCP |
-| Storytelling for Impact | `storytelling-for-impact/` | Craft compelling stories for presentations and influence |
-| Write Teachable Personal Moment | `write-teachable-personal-moment/` | Story-first long-form posts in a teachable-moment voice |
-| Write as Jason | `write-as-jason/` | Content in Jason's authentic voice |
-| Engineering Foundations | `engineering-foundations/` | Repeatable engineering fundamentals |
+| Skill | Path |
+|-------|------|
+| Create PRD | `create-prd/` |
+| Create PRD (Claude Code) | `create-prd-claude-code/` |
+| Create PRD (Engineering) | `create-prd-engineering/` |
+| Create PRD (One-Pager) | `create-prd-one-pager/` |
+| Decision Brief | `decision-brief/` |
+| Question Storming | `question-storming/` |
+| Jobs to Be Done | `jobs-to-be-done/` |
+| Create User Interview | `create-user-interview/` |
+| Analyze User Interview | `analyze-user-interview/` |
+| DevEx Survey | `devex-survey/` |
+| Architecture Diagram | `create-architecture-diagram/` |
+| Release Notes | `create-release-notes/` |
+| Sourcegraph Search | `sourcegraph-search/` |
+| Storytelling for Impact | `storytelling-for-impact/` |
+| Write Teachable Moment | `write-teachable-personal-moment/` |
+| Write as Jason | `write-as-jason/` |
+| Engineering Foundations | `engineering-foundations/` |
 
-### Planned Skills (`todo-` prefix)
+### Planned Skills (not yet built)
 
-Placeholders awaiting build-out. Remove the `todo-` prefix when fully built.
-
-| Skill | Path | Description |
-|-------|------|-------------|
-| Analyze User Feedback | `todo-analyze-user-feedback/` | Extract themes and sentiment from surveys, interviews, Slack |
-| Automate Review Process | `todo-automate-review-process/` | Automate code reviews, design reviews, approval workflows |
-| Convert Zoom Notes | `todo-convert-zoom-notes/` | Zoom transcripts into structured Obsidian notes |
-| Create Figma Mockup | `todo-create-figma-mockup/` | Figma mockups from PRDs or design briefs |
-| GTM Plan | `todo-gtm-plan/` | Go-To-Market plan: positioning, enablement, launch timing |
-| Launch Checklist | `todo-launch-checklist/` | Product launch readiness, sign-off, go/no-go |
-| Map Stakeholders | `todo-map-stakeholders/` | Map decision makers, influencers, blockers |
-| Prioritize Features | `todo-prioritize-features/` | Feature prioritization using RICE, Kano, or custom frameworks |
-| Validate Hypothesis | `todo-validate-hypothesis/` | Structured hypotheses and validation plans |
+`todo-analyze-user-feedback` · `todo-automate-review-process` · `todo-convert-zoom-notes` · `todo-create-figma-mockup` · `todo-gtm-plan` · `todo-launch-checklist` · `todo-map-stakeholders` · `todo-prioritize-features` · `todo-validate-hypothesis`
 
 ### Lenny's PM Skills (88 skills)
 
-Curated from [Lenny's Podcast](https://www.lennyspodcast.com/). All live in `.claude/skills/lenny-podcast/`.
-See the full catalog: [lenny-podcast/README.md](.claude/skills/lenny-podcast/README.md).
-
----
-
-## PM Operating Philosophy
-
-### Guiding Principles
-
-Five values that guide all decision-making:
-
-1. **Humility** — No one has all the answers. Listen before asserting. Ask before assuming.
-2. **Transparency** — Default to open. Share context, reasoning, and trade-offs. Show your work.
-3. **Empathy for Customers** — Every decision traces back to a real person. Ask "what hurts the most?" before prioritizing.
-4. **Grit** — Hard problems don't yield to the first attempt. Keep iterating when the easy path is to move on.
-5. **Innovate** — Challenge the default. Ask "what if?" before accepting "that's how we do it."
-
-### Multidisciplinary Collaboration
-
-> "There is no harmony in a one-person band." — [Multidisciplinary Harmony](https://medium.com/@jasmea/multidisciplinary-harmony-9257d315798b)
-
-Product teams work like jazz ensembles. Each role has a home base, not a cage:
-
-- **PM** owns the what and why. **Engineer** owns the how. **Designer** owns the experience. **TPM** owns the delivery. **UXR** owns the evidence.
-- Best work happens when people cross into each other's territory with curiosity.
-- At the start of any initiative, discuss who owns what openly. Gaps drop balls; overlap creates friction.
-- No skill in this repo belongs to a single role. Value compounds when multiple disciplines engage.
-
-### Collaboration via Git
-
-Skills are code. PMs define workflows as version-controlled skill files. Engineers review via PRs. AI tools execute.
-
-1. PM creates or updates a skill on a branch.
-2. Opens a PR — explains what changed and why.
-3. Engineers review for clarity and feasibility. Designers, UXR, TPMs review if the skill touches their domain.
-4. Merge to main. The skill is live for the team.
-
-### PM Competency Model
-
-5 areas, 6 levels (Learner → Contributor → Specialist → Expert → Company Leader → Industry Leader).
-
-| Area | Sub-Competencies |
-|------|-----------------|
-| **Vision & Strategy** | Current Product Understanding, Future Product Vision |
-| **Project** | Communication, Project Leadership & Execution |
-| **Technical** | Technical Depth, Technical Breadth, Customer Experience |
-| **Business** | Product-Market Fit, Business Growth |
-| **People Management** | Retention, Career Growth, Hiring, Productivity |
+All in `.claude/skills/lenny-podcast/`. Catalog: [lenny-podcast/README.md](.claude/skills/lenny-podcast/README.md).


### PR DESCRIPTION
- Strip Atlassian section from AGENTS.md; compress file by ~68%
- Rewrite analyze-user-interview to use local markdown notes instead of Confluence pages; output always saves to Desktop as .md
- Rewrite create-release-notes to use GitLab MRs + user feature list as source of truth; removes Jira and Confluence phases entirely
- Remove Jira Epic fields from all PRD templates (create-prd, create-prd-engineering, create-prd-claude-code)
- Update create-prd and create-prd-engineering skill docs to reference markdown/design docs instead of Jira epics or Confluence pages
- Update jobs-to-be-done to remove Jira-specific language